### PR TITLE
add JSSERVE_LISTEN_URL to switch listen url

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
+authors = ["SimonDanisch <sdanisch@gmail.com>"]
 name = "JSServe"
 uuid = "824d6782-a2ef-11e9-3a09-e5662e0c26f9"
-authors = ["SimonDanisch <sdanisch@gmail.com>"]
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -23,6 +23,8 @@ WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 WidgetsBase = "eead4739-05f7-45a1-878c-cee36b57321c"
 
 [compat]
+AbstractTrees = "0.3"
+Colors = "0.12"
 HTTP = "0.8"
 Hyperscript = "0.0.3"
 JSON3 = "0.1, 1.0"
@@ -32,8 +34,6 @@ Tables = "1"
 WebSockets = "1.5"
 WidgetsBase = "0.1"
 julia = "1.3"
-AbstractTrees = "0.3"
-Colors = "0.12"
 
 [extras]
 Electron = "a1bb12fb-d4d1-54b4-b10a-ee7951ef7ad3"

--- a/src/JSServe.jl
+++ b/src/JSServe.jl
@@ -61,6 +61,7 @@ function __init__()
     if endswith(url, "/")
         url = url[1:end-1]
     end
+    JSSERVE_CONFIGURATION.listen_url[] = get(ENV, "JSSERVE_LISTEN_URL", "127.0.0.1")
     JSSERVE_CONFIGURATION.websocket_proxy[] = url
     JSSERVE_CONFIGURATION.content_delivery_url[] = url
     JSSERVE_CONFIGURATION.listen_port[] = parse(Int, get(ENV, "WEBIO_HTTP_PORT", "8081"))


### PR DESCRIPTION
Setting `ENV["JSSERVE_LISTEN_URL"] = "0.0.0.0"` before using JSServe lets you change the url the server is listening to.