### PR TITLE
html fixes for tables and buttons

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1,8 +1,7 @@
 # Render the widgets from WidgetsBase.jl
 function jsrender(session::Session, button::Button)
-    return jsrender(session, DOM.input(
-        type = "button",
-        value = button.content,
+    return jsrender(session, DOM.button(
+        button.content,
         onclick = js"JSServe.update_obs($(button.value), true);";
         button.attributes...
     ))

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -111,7 +111,7 @@ function JSServe.jsrender(session::Session, table::Table)
     header = DOM.thead(DOM.tr(DOM.th.(names)...))
     rows = []
     for row in Tables.rows(table.table)
-        push!(rows, DOM.tr(DOM.th.(table.row_renderer.(values(row)))...))
+        push!(rows, DOM.tr(DOM.td.(table.row_renderer.(values(row)))...))
     end
     body = DOM.tbody(rows...)
     return DOM.table(header, body; class=table.class)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -64,14 +64,14 @@ end
 
 function test_current_session(app)
     dom = children(app.dom)[1]
-    @test evaljs(app, js"document.querySelectorAll('input[type=\"button\"]').length") == 1
+    @test evaljs(app, js"document.querySelectorAll('button').length") == 1
     @test evaljs(app, js"document.querySelectorAll('input[type=\"range\"]').length") == 2
-    @test evaljs(app, js"document.querySelectorAll('input[type=\"button\"]').length") == 1
+    @test evaljs(app, js"document.querySelectorAll('button').length") == 1
     @test evaljs(app, js"document.querySelectorAll('input[type=\"range\"]').length") == 2
 
     @testset "button" begin
         # It's in the dom!
-        @test evaljs(app, js"document.querySelectorAll('input[type=\"button\"]').length") == 1
+        @test evaljs(app, js"document.querySelectorAll('button').length") == 1
         bquery = query_testid("hi_button")
         # Spam the button press on the JS side a bit, to make sure we're not loosing events!
         for i in 1:100
@@ -84,7 +84,7 @@ function test_current_session(app)
         @test button.content[] == "hi"
         button.content[] = "new name"
         bquery = query_testid("hi_button")
-        @test evaljs(app, js"$(bquery).value") == "new name"
+        @test evaljs(app, js"$(bquery).innerText") == "new name"
         # button press from Julia
         val = test_value(app, ()-> (button.value[] = true))
         @test val["button"] == true


### PR DESCRIPTION
This does a couple of simple fixes to the markup of buttons and tables.

For buttons, `<input type=button/>` does not exist, with this PR JSServe generates the `<button>` tag instead. Main difference is that when you style it with for example Tailwind, as in:

```julia
app = App() do
       btn = Button("Click here!", class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded")
       return DOM.div(JSServe.TailwindCSS, btn)
end
```

you get the nice "hand-shaped cursor" when hovering on the button.

For tables, it replaces `th` (table header) with `td` (table data) for data rows, so they are not rendered in bold by default (only the header is).