### PR TITLE
safer openurl

### DIFF
--- a/src/browser_display.jl
+++ b/src/browser_display.jl
@@ -18,18 +18,32 @@ function browser_display()
     return
 end
 
+"""
+    tryrun(cmd::Cmd)
+
+Try to run a command. Return `true` if `cmd` runs and is successful (exits with a code of `0`).
+Return `false` otherwise.
+"""
+function tryrun(cmd::Cmd)
+    try
+        return success(cmd)
+    catch e
+        return false
+    end
+end
+
 function openurl(url::String)
     if Sys.isapple()
-        success(`open $url`) && return
+        tryrun(`open $url`) && return
     elseif Sys.iswindows()
-        success(`powershell.exe start $url`) && return
+        tryrun(`powershell.exe start $url`) && return
     elseif Sys.isunix()
-        success(`xdg-open $url`) && return
-        success(`gnome-open $url`) && return
+        tryrun(`xdg-open $url`) && return
+        tryrun(`gnome-open $url`) && return
     end
-    success(`python -mwebbrowser $(url)`) && return
+    tryrun(`python -mwebbrowser $(url)`) && return
     # our last hope
-    success(`python3 -mwebbrowser $(url)`) && return
+    tryrun(`python3 -mwebbrowser $(url)`) && return
     @warn("Can't find a way to open a browser, open $(url) manually!")
 end
 

--- a/test/various.jl
+++ b/test/various.jl
@@ -108,3 +108,7 @@ end
     JSServe.register_resource!(s, div)
     @test JSTest.assets[1] in s.dependencies
 end
+
+@testset "tryrun" begin
+    @test JSServe.tryrun(`fake_command`) == false
+end


### PR DESCRIPTION
Fix #98 by using `tryrun`, which does not throw and returns `false` if something goes wrong (either external process cannot be started or it returns error).

On a related note, do we also want to make it customizable whether JSServe tries to open the browser? I'm using `display(app)` to start serving an app on tmux, and I don't necessarily want the server to try and open a browser (but maybe I'm doing things the wrong way and there is another command to just start serving).