### PR TITLE
Replace Point2f0 with Point2f, FRect2D with Rect2f, etc.

### DIFF
--- a/examples/basic_offline_makie.jl
+++ b/examples/basic_offline_makie.jl
@@ -9,7 +9,7 @@ rows(args...; class="") = DOM.div(args..., class=class * " flex flex-row")
 css_color(c) = "background-color: #$(hex(c))"
 using MakieGallery, FileIO
 # get a somewhat interesting point cloud:
-cat = decompose(Point3f0, MakieGallery.loadasset("cat.obj"))
+cat = decompose(Point3f, MakieGallery.loadasset("cat.obj"))
 # Create a little interactive app
 function App(session, request)
     markersize = JSServe.Slider(range(1, stop=20, step=0.1))

--- a/examples/markdown.jl
+++ b/examples/markdown.jl
@@ -31,7 +31,7 @@ app = App() do
     end
     fig = Figure()
 
-    vol = volume(fig[1,1], signal; algorithm=map(Symbol, algorithm), ambient=Vec3f0(0.8), isovalue=iso_value)
+    vol = volume(fig[1,1], signal; algorithm=map(Symbol, algorithm), ambient=Vec3f(0.8), isovalue=iso_value)
 
     colormaps = collect(AbstractPlotting.all_gradient_names)
     cmap = map(cmap_button) do click

--- a/examples/oceananigans.jl
+++ b/examples/oceananigans.jl
@@ -47,9 +47,9 @@ function handler(s, r)
         restrict(volume_frames[idx])
     end
     clims = (8, 12)
-    cmapa = RGBAf0.(to_colormap(:thermal), 1.0)
-    cmap1 = vcat(fill(RGBAf0(0,0,0,0), 20), cmapa)
-    cmap2 = vcat(cmapa, fill(RGBAf0(0,0,0,0), 20))
+    cmapa = RGBAf.(to_colormap(:thermal), 1.0)
+    cmap1 = vcat(fill(RGBAf(0,0,0,0), 20), cmapa)
+    cmap2 = vcat(cmapa, fill(RGBAf(0,0,0,0), 20))
     cmap = map(flip_colormap) do x
         return x ? copy(cmap1) : copy(cmap2)
     end

--- a/examples/wglmakie.jl
+++ b/examples/wglmakie.jl
@@ -14,8 +14,8 @@ app = App() do
     return hbox(
         vbox(
             scatter(1:4, color=1:4),
-            scatter(1:4, color=rand(RGBAf0, 4)),
-            scatter(1:4, color=rand(RGBf0, 4)),
+            scatter(1:4, color=rand(RGBAf, 4)),
+            scatter(1:4, color=rand(RGBf, 4)),
             scatter(1:4, color=:red),
             scatter(1:4)
         ),
@@ -23,7 +23,7 @@ app = App() do
             scatter(1:4, marker='☼'),
             scatter(1:4, marker=['☼', '◒', '◑', '◐']),
             scatter(1:4, marker="☼◒◑◐"),
-            # scatter(1:4, marker=rand(RGBf0, 10, 10), markersize=20px),
+            # scatter(1:4, marker=rand(RGBf, 10, 10), markersize=20px),
             scatter(1:4, markersize=20px),
             scatter(1:4, markersize=20, markerspace=Pixel),
             scatter(1:4, markersize=LinRange(20, 60, 4), markerspace=Pixel),
@@ -37,11 +37,11 @@ display(app)
 app = App() do
     return DOM.div(
         meshscatter(1:4, color=1:4),
-        meshscatter(1:4, color=rand(RGBAf0, 4)),
-        meshscatter(1:4, color=rand(RGBf0, 4)),
+        meshscatter(1:4, color=rand(RGBAf, 4)),
+        meshscatter(1:4, color=rand(RGBf, 4)),
         meshscatter(1:4, color=:red),
-        meshscatter(rand(Point3f0, 10), color=rand(RGBf0, 10)),
-        meshscatter(rand(Point3f0, 10), marker=Pyramid(Point3f0(0), 1f0, 1f0)),
+        meshscatter(rand(Point3f, 10), color=rand(RGBf, 10)),
+        meshscatter(rand(Point3f, 10), marker=Pyramid(Point3f(0), 1f0, 1f0)),
     )
 end
 
@@ -49,14 +49,14 @@ display(app)
 
 
 app = App() do
-    x = Point2f0[(1, 1), (2, 2), (3, 2), (4, 4)]
+    x = Point2f[(1, 1), (2, 2), (3, 2), (4, 4)]
     points = connect(x, LineFace{Int}[(1, 2), (2, 3), (3, 4)])
     return DOM.div(
         linesegments(1:4),
         linesegments(1:4, linestyle=:dot),
         linesegments(1:4, linestyle=[0.0, 1.0, 2.0, 3.0, 4.0]),
         linesegments(1:4, color=1:4),
-        linesegments(1:4, color=rand(RGBf0, 4), linewidth=10),
+        linesegments(1:4, color=rand(RGBf, 4), linewidth=10),
         linesegments(points)
     )
 end
@@ -64,14 +64,14 @@ end
 display(app)
 
 app = App() do
-    x = Point2f0[(1, 1), (2, 2), (3, 2), (4, 4)]
+    x = Point2f[(1, 1), (2, 2), (3, 2), (4, 4)]
     points = connect(x, LineFace{Int}[(1, 2), (2, 3), (3, 4)])
     return DOM.div(
         lines(1:4),
         lines(1:4, linestyle=:dot),
         lines(1:4, linestyle=[0.0, 1.0, 2.0, 3.0, 4.0]),
         lines(1:4, color=1:4),
-        lines(1:4, color=rand(RGBf0, 4), linewidth=10),
+        lines(1:4, color=rand(RGBf, 4), linewidth=10),
         lines(points)
     )
 end
@@ -83,7 +83,7 @@ app = App() do
     return hbox(vbox(
         surface(-10..10, -10..10, data, show_axis=false),
         surface(-10..10, -10..10, data, color=rand(size(data)...))),
-        vbox(surface(-10..10, -10..10, data, color=rand(RGBf0, size(data)...)),
+        vbox(surface(-10..10, -10..10, data, color=rand(RGBf, size(data)...)),
         surface(-10..10, -10..10, data, colormap=:magma, colorrange=(0.0, 2.0)),
     ))
 end
@@ -94,10 +94,10 @@ app = App() do
     return vbox(
         image(rand(10, 10)),
         heatmap(rand(10, 10)),
-        image(rand(RGBAf0, 10, 10)),
-        heatmap(rand(RGBAf0, 10, 10)),
-        image(rand(RGBf0, 10, 10)),
-        heatmap(rand(RGBf0, 10, 10)),
+        image(rand(RGBAf, 10, 10)),
+        heatmap(rand(RGBAf, 10, 10)),
+        image(rand(RGBf, 10, 10)),
+        heatmap(rand(RGBf, 10, 10)),
     )
 end
 
@@ -110,7 +110,7 @@ app = App() do
         volume(1..2, -1..1, -3..(-2), rand(4, 4, 4), algorithm=:absorption)),
         vbox(
         volume(rand(4, 4, 4), algorithm=Int32(5)),
-        volume(rand(RGBAf0, 4, 4, 4), algorithm=:absorptionrgba),
+        volume(rand(RGBAf, 4, 4, 4), algorithm=:absorptionrgba),
         contour(rand(4, 4, 4)),
     ))
 end
@@ -122,8 +122,8 @@ app = App() do
     cat = FileIO.load(MakieGallery.assetpath("cat.obj"))
     tex = FileIO.load(MakieGallery.assetpath("diffusemap.png"))
     return hbox(vbox(
-        AbstractPlotting.mesh(Circle(Point2f0(0), 1f0)),
-        AbstractPlotting.poly(decompose(Point2f0, Circle(Point2f0(0), 1f0)))), vbox(
+        AbstractPlotting.mesh(Circle(Point2f(0), 1f0)),
+        AbstractPlotting.poly(decompose(Point2f, Circle(Point2f(0), 1f0)))), vbox(
         AbstractPlotting.mesh(cat, color=tex),
         AbstractPlotting.mesh([(0.0, 0.0), (0.5, 1.0), (1.0, 0.0)]; color=[:red, :green, :blue], shading=false)
     ))
@@ -159,12 +159,12 @@ function n_times(f, n=10, interval=1)
 end
 
 app = App() do
-    s1 = annotations(n_times(i-> map(j-> ("$j", Point2f0(j*30, 0)), 1:i)), textsize=20,
-                      limits=FRect2D(30, 0, 320, 50))
-    s2 = scatter(n_times(i-> Point2f0.((1:i).*30, 0)), markersize=20px,
-                  limits=FRect2D(30, 0, 320, 50))
-    s3 = linesegments(n_times(i-> Point2f0.((2:2:2i).*30, 0)), limits=FRect2D(30, 0, 620, 50))
-    s4 = lines(n_times(i-> Point2f0.((2:2:2i).*30, 0)), limits=FRect2D(30, 0, 620, 50))
+    s1 = annotations(n_times(i-> map(j-> ("$j", Point2f(j*30, 0)), 1:i)), textsize=20,
+                      limits=Rect2f(30, 0, 320, 50))
+    s2 = scatter(n_times(i-> Point2f.((1:i).*30, 0)), markersize=20px,
+                  limits=Rect2f(30, 0, 320, 50))
+    s3 = linesegments(n_times(i-> Point2f.((2:2:2i).*30, 0)), limits=Rect2f(30, 0, 620, 50))
+    s4 = lines(n_times(i-> Point2f.((2:2:2i).*30, 0)), limits=Rect2f(30, 0, 620, 50))
     return hbox(s1, s2, s3, s4)
 end
 
@@ -175,7 +175,7 @@ app = App() do
     outer_padding = 30
     scene, layout = layoutscene(
         outer_padding, resolution=(1200, 700),
-        backgroundcolor=RGBf0(0.98, 0.98, 0.98)
+        backgroundcolor=RGBf(0.98, 0.98, 0.98)
     )
     ax1 = layout[1, 1] = LAxis(scene, title="Sine")
     xx = 0:0.2:4pi
@@ -228,11 +228,11 @@ display(app)
 
 app = App() do
     sl = JSServe.Slider(1:10)
-    rect = FRect2D(0, -5, 1025, 10)
+    rect = Rect2f(0, -5, 1025, 10)
     chars = [collect('a':'z'); 0:9;]
     char2 = [collect('A':'Z'); 0:9;]
-    tex1 = map(x->map(j-> ("$(chars[rand(1:length(chars))])", Point2f0(j*30, 0)), 1:36), sl)
-    tex2 = map(x->map(j-> ("$(char2[rand(1:length(char2))])", Point2f0(j*30, 1)), 1:36), sl)
+    tex1 = map(x->map(j-> ("$(chars[rand(1:length(chars))])", Point2f(j*30, 0)), 1:36), sl)
+    tex2 = map(x->map(j-> ("$(char2[rand(1:length(char2))])", Point2f(j*30, 1)), 1:36), sl)
     scene = annotations(tex1, textsize=20, limits=rect, show_axis=false)
     annotations!(scene, tex2, textsize=20, limits=rect, show_axis=false)
     return DOM.div(sl, scene)


### PR DESCRIPTION
This switches to new GeometryBasics type names from JuliaGeometry/GeometryBasics.jl#97.

I couldn't get the examples to run, but I don't think this PR breaks anything.