### PR TITLE
remove reliance on 127.0.0.1 and other ipv4 addresses

### DIFF
--- a/src/JSServe.jl
+++ b/src/JSServe.jl
@@ -38,7 +38,7 @@ include("browser_display.jl")
 
 const JSSERVE_CONFIGURATION = (
     # The URL used to which the default server listens to
-    listen_url = Ref("127.0.0.1"),
+    listen_url = Ref("localhost"),
     # The Port to which the default server listens to
     listen_port = Ref(9284),
     # The url Javascript uses to connect to the websocket.
@@ -67,7 +67,7 @@ Configures the parameters for the automatically started server.
 
     * listen_url=JSSERVE_CONFIGURATION.listen_url[]
         The address the server listens to.
-        must be 0.0.0.0, 127.0.0.1 or localhost.
+        must be 0.0.0.0, 127.0.0.1, ::, ::1, or localhost.
         If not set differently by an ENV variable, will default to 127.0.0.1
 
     * listen_port::Integer=JSSERVE_CONFIGURATION.listen_port[],

--- a/src/server.jl
+++ b/src/server.jl
@@ -101,7 +101,7 @@ end
 
 function websocket_request()
     headers = [
-        "Host" => "127.0.0.1",
+        "Host" => "localhost",
         "User-Agent" => "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0",
         "Accept" => "*/*",
         "Accept-Encoding" => "gzip, deflate, br",
@@ -292,7 +292,7 @@ end
 
 function start(application::Server; verbose=false)
     isrunning(application) && return
-    address = Sockets.InetAddr(parse(Sockets.IPAddr, application.url), application.port)
+    address = Sockets.InetAddr(Sockets.getaddrinfo(application.url), application.port)
     ioserver = Sockets.listen(address)
     application.server_connection[] = ioserver
     # pass tcp connection to listen, so that we can close the server


### PR DESCRIPTION
This PR enables the use of hostnames such as "localhost" and removes the reliance on ipv4 by utilizing getaddrinfo instead of parsing an IPv4 address.

