### PR TITLE
set doctype in page

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -400,7 +400,7 @@ end
 
 """
     page_html(session::Session, html_body)
-Embedds the html_body in a standalone html document!
+Embeds the html_body in a standalone html document!
 """
 function page_html(session::Session, html)
     proxy_url = JSSERVE_CONFIGURATION.external_url[]
@@ -427,7 +427,7 @@ function page_html(session::Session, html)
             """)
         )
     )
-    return repr(MIME"text/html"(), Hyperscript.Pretty(html_body))
+    return Hyperscript.wraphtml(Hyperscript.Pretty(html_body))
 end
 
 function Base.show(io::IOContext, m::MIME"application/vnd.jsserve.application+html", dom::App)

--- a/src/display.jl
+++ b/src/display.jl
@@ -427,7 +427,10 @@ function page_html(session::Session, html)
             """)
         )
     )
-    return Hyperscript.wraphtml(Hyperscript.Pretty(html_body))
+    return sprint() do io
+        println(io, "<!doctype html>")
+        show(io, MIME"text/html"(), Hyperscript.Pretty(html_body))
+    end
 end
 
 function Base.show(io::IOContext, m::MIME"application/vnd.jsserve.application+html", dom::App)


### PR DESCRIPTION
The key difference is that the helper `Hyperscript.wraphtml` also sets the `DOCTYPE` in the html page, see [here](https://github.com/JuliaWeb/Hyperscript.jl/blob/0ef32362062c580077020a85ca6edaec7dbdc1b8/src/Hyperscript.jl#L500).

If we don't want to depend on a Hyperscript helper function, I imagine something like

```julia
sprint() do io
    println(io, "<!doctype html>")
    show(io, MIME"text/html"(), Hyperscript.Pretty(html_body))
end
```

would also work.

UPDATE: I've actually moved away from `wraphtml` because it was "double-wrapping" in the `<html>` tag and am simply adding the doctype by hand