### PR TITLE
add Base.wait(::Server)

### DIFF
--- a/examples/basics.jl
+++ b/examples/basics.jl
@@ -100,6 +100,7 @@ end
 display(app)
 
 JSServe.route!(get_server(), "/example1" => app)
+#wait(get_server()) # This call will block execution of the script and bring the server event loop to the foreground
 
 app = App() do session::Session
     slider = JSServe.Slider(1:10, class="slider m-4")

--- a/examples/serve.jl
+++ b/examples/serve.jl
@@ -20,3 +20,4 @@ end
 isdefined(Main, :server) && close(server)
 
 server = JSServe.Server(app, "127.0.0.1", 8081)
+wait(server)

--- a/src/server.jl
+++ b/src/server.jl
@@ -322,3 +322,8 @@ function insert_session!(server::Server, session=Session())
     server.sessions[session.id] = session
     return session
 end
+
+"""Wait on the server task, i.e. block execution by bringing the server event loop to the foreground."""
+function Base.wait(server::Server)
+    wait(server.server_task[])
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -192,6 +192,9 @@ end
 
 """
 The application one serves
+
+The server event loop can be brought to the foreground with
+`wait(server::Server)`.
 """
 struct Server
     url::String


### PR DESCRIPTION
Provide an official way to wait on the server event loop.

Based on discourse post https://discourse.julialang.org/t/a-headless-non-interactive-jsserve-and-wglmakie-server/90549