### PR TITLE
setup TSConfig and Deno extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "denoland.vscode-deno",
+        "julialang.language-julia"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "deno.enable": true
+}

--- a/js_dependencies/JSServe.js
+++ b/js_dependencies/JSServe.js
@@ -80,6 +80,7 @@ const JSServe = {
     lookup_observable,
 };
 
+// @ts-ignore
 window.JSServe = JSServe;
 
 export {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "module": "ES2020",
+        "lib": ["ES2021", "DOM", "WebWorker", "DOM.Iterable"],
+        "allowJs": true,
+        "checkJs": true,
+        "noEmit": true,
+        "strict": false,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "esModuleInterop": true,
+        "strictNullChecks": true,
+        "skipDefaultLibCheck": true
+    },
+    "include": ["js_dependencies/**/*.js"],
+    "exclude": []
+}


### PR DESCRIPTION
TSConfig removes guesswork from VS Code about which types are available, it is currently set to "this will run in a modern browser".

This currently mostly gives some null errors, you could fix those (yay), or disable them by setting `"strictNullChecks"` to `false`.

The Deno VS Code extension provides typings for your CDN imports. The means that something like `Pako.deflate` gives types/documentation on hover, and it can be type checked as part of your code.

In Pluto we also set up CI to run the TSC checks (with null checks disabled), which is nice for new contributors: https://github.com/fonsp/Pluto.jl/blob/main/.github/workflows/TypeScriptCheck.yml