### PR TITLE
mention `proxy_url` in the serve.jl example

### DIFF
--- a/examples/serve.jl
+++ b/examples/serve.jl
@@ -23,6 +23,8 @@ if isdefined(Main, :server)
 end
 
 server = JSServe.Server(app, "127.0.0.1", 8081)
+# Important Note: You might want to set the keyword argument `proxy_url` above in case
+# you have a reverse proxy (like nginx or caddy) in front of the JSServe instance.
 JSServe.HTTPServer.start(server)
 # JSServe.HTTPServer.route!(server, "/" => app) # Overwrite app after changing it
 wait(server)


### PR DESCRIPTION
Updating from 1.2 to 2.0 caused me some confusion (my reverse proxy stopped working), so I thought mentioning this might be helpful for others.