### PR TITLE
remove compression

### DIFF
--- a/js_dependencies/Protocol.js
+++ b/js_dependencies/Protocol.js
@@ -221,10 +221,10 @@ export function decode_base64_message(base64_string) {
 }
 
 export function decode_binary(binary) {
-    const msg_binary = Pako.inflate(binary);
-    return unpack(msg_binary);
+    // const msg_binary = Pako.inflate();
+    return unpack(binary);
 }
 
 export function encode_binary(data) {
-    return Pako.deflate(pack(data));
+    return pack(data);
 }

--- a/src/serialization/serialization.jl
+++ b/src/serialization/serialization.jl
@@ -5,16 +5,15 @@ include("protocol.jl")
 
 function serialize_binary(session::Session, @nospecialize(obj))
     data = serialize_cached(session, obj)
-    return transcode(GzipCompressor, MsgPack.pack(data))
+    return MsgPack.pack(data)
 end
 
 function serialize_binary(session::Session, msg::SerializedMessage)
-    return transcode(GzipCompressor, MsgPack.pack(msg))
+    return MsgPack.pack(msg)
 end
 
 function deserialize_binary(bytes::AbstractVector{UInt8})
-    message_msgpacked = transcode(GzipDecompressor, bytes)
-    return MsgPack.unpack(message_msgpacked)
+    return MsgPack.unpack(bytes)
 end
 
 function deserialize(msg::SerializedMessage)


### PR DESCRIPTION
This is a work in progress, we shouldn't just enable it but instead make it configurable...
We could use the same infrastructure that we use for setting the default connection + asset_serving type:
https://github.com/SimonDanisch/JSServe.jl/blob/master/src/registry.jl#L154
So one can explicitly do `Session(protocol=NoCompression())` or do `force_protocol!(NoCompression())` to pick it up in the session that gets created inside `show`.