### PR TITLE
[HOTFIX] Partial rollback of caching logic

### DIFF
--- a/js_dependencies/JSServe.bundled.js
+++ b/js_dependencies/JSServe.bundled.js
@@ -3243,6 +3243,7 @@ function init_session(session_id, binary_messages, session_status) {
         }
         done_initializing_session(session_id);
     } catch (error) {
+        console.warn(`init of session ${session_id} failed with error: ${error}`);
         send_done_loading(session_id, error);
     } finally{
         OBJECT_FREEING_LOCK.task_unlock(session_id);
@@ -3316,6 +3317,7 @@ function update_session_dom(message) {
             process_message(messages);
             done_initializing_session(session_id);
         } catch (error) {
+            console.warn(`Failed to update session ${session_id} dom`);
             send_done_loading(session_id, error);
         } finally{
             OBJECT_FREEING_LOCK.task_unlock(session_id);

--- a/js_dependencies/Sessions.js
+++ b/js_dependencies/Sessions.js
@@ -148,6 +148,7 @@ export function init_session(session_id, binary_messages, session_status) {
         }
         done_initializing_session(session_id);
     } catch (error) {
+        console.warn(`init of session ${session_id} failed with error: ${error}`);
         send_done_loading(session_id, error);
     } finally {
         OBJECT_FREEING_LOCK.task_unlock(session_id);
@@ -234,6 +235,7 @@ export function update_session_dom(message) {
             process_message(messages);
             done_initializing_session(session_id);
         } catch (error) {
+            console.warn(`Failed to update session ${session_id} dom`);
             send_done_loading(session_id, error);
         } finally {
             // this locks corresponds to the below task_lock from update session cache for an unitialized session


### PR DESCRIPTION
This PR should fix #123 https://github.com/Ferrite-FEM/FerriteViz.jl/pull/70 https://github.com/MakieOrg/Makie.jl/issues/1343 https://github.com/fonsp/Pluto.jl/issues/1822

The current implementation of shared caching between sessions is a bit of a problem, because I do not know if there is a way to force the correct over the execution order of the JS modules placed into Documenter.jl, such that consecutive figures are properly loaded in-order. This PR contains a rollback and console logging of the errors (which can be triggered by just using the first commit in this PR).