### PR TITLE
Improvements for static export workflow

### DIFF
--- a/js_dependencies/markdown.css
+++ b/js_dependencies/markdown.css
@@ -365,7 +365,7 @@
 
 .markdown-body ol ol,
 .markdown-body ul ol {
-    list-style-type: lower-roman;
+    list-style-type: disk;
 }
 
 .markdown-body ol ol ol,

--- a/src/HTTPServer/implementation.jl
+++ b/src/HTTPServer/implementation.jl
@@ -92,7 +92,10 @@ function delegate(routes::Routes, application, request::Request, args...)
 end
 
 function match_request(pattern::String, request)
-    return request.target == pattern ? pattern : nothing
+    request.target == pattern && return pattern
+    uri = URI(request.target)
+    uri.path == pattern && return pattern
+    return nothing
 end
 
 function match_request(pattern::Regex, request)

--- a/src/JSServe.jl
+++ b/src/JSServe.jl
@@ -36,6 +36,13 @@ include("types.jl")
 include("HTTPServer/HTTPServer.jl")
 include("app.jl")
 
+function HTTPServer.route!(server::HTTPServer.Server, routes::Routes)
+    for (key, app) in routes.routes
+        HTTPServer.route!(server, key => app)
+    end
+end
+
+
 import .HTTPServer: browser_display
 using .HTTPServer: Server, html, online_url, route!, file_mimetype, delete_websocket_route!, delete_route!, use_electron_display
 
@@ -56,6 +63,7 @@ include("widgets.jl")
 include("display.jl")
 include("export.jl")
 include("tailwind-dashboard.jl")
+include("interactive.jl")
 
 # Core functionality
 export Page, Session, App, DOM, SVG, @js_str, ES6Module, Asset
@@ -65,7 +73,7 @@ export Observable, on, onany, bind_global
 export linkjs, evaljs, evaljs_value, onjs
 export NoServer, AssetFolder, HTTPAssetServer, DocumenterAssets
 export NoConnection, IJuliaConnection, PlutoConnection, WebSocketConnection
-export export_static
+export export_static, Routes, interactive_server
 
 
 function has_html_display()

--- a/src/asset-serving/asset.jl
+++ b/src/asset-serving/asset.jl
@@ -25,7 +25,7 @@ function unique_file_key(asset::BinaryAsset)
     return "$key.$ext"
 end
 
-url(session::Session, asset::Union{BinaryAsset, Asset}) = url(session.asset_server, asset)
+url(session::Session, asset::Union{BinaryAsset, Asset, Link}) = url(session.asset_server, asset)
 function url(::Nothing, asset::Asset)
     # Allow to use nothing for specifying an online url
     @assert !isempty(asset.online_path)

--- a/src/asset-serving/http.jl
+++ b/src/asset-serving/http.jl
@@ -22,6 +22,8 @@ function Base.close(server::HTTPAssetServer)
     empty!(server.registered_files)
 end
 
+url(server::HTTPAssetServer, link::Link) = link.target
+
 function url(server::HTTPAssetServer, asset::Asset)
     file = local_path(asset)
     isempty(file) && return asset.online_path

--- a/src/asset-serving/no-server.jl
+++ b/src/asset-serving/no-server.jl
@@ -70,7 +70,8 @@ function desired_location(assetfolder, asset)
 end
 
 function desired_location(assetfolder, asset::BinaryAsset)
-    folder = abspath(assetfolder.folder[])
+    dir = assetfolder.folder isa Ref ? assetfolder.folder[] : assetfolder.folder
+    folder = abspath(dir)
     file = unique_file_key(asset)
     sub = subdir(asset)
     return normpath(joinpath(folder, "jsserve", sub, file))
@@ -94,7 +95,7 @@ function url(assetfolder::AbstractAssetFolder, asset::Asset)
         return asset.online_path
     end
     path = write_to_assetfolder(assetfolder, asset)
-    return "/" * replace(normpath(relpath(path, folder(assetfolder))), "\\" => "/")
+    return "./" * replace(normpath(relpath(path, folder(assetfolder))), "\\" => "/")
 end
 
 folder(assetfolder::AssetFolder) = abspath(assetfolder.folder)

--- a/src/asset-serving/no-server.jl
+++ b/src/asset-serving/no-server.jl
@@ -49,14 +49,18 @@ end
 
 abstract type AbstractAssetFolder <: AbstractAssetServer end
 
-struct AssetFolder <: AbstractAssetFolder
+mutable struct AssetFolder <: AbstractAssetFolder
     folder::String
+    current_dir::String # The dir the current html page gets written out to
 end
 Base.similar(asset::AssetFolder) = asset # no copy needed
 
 setup_asset_server(::AbstractAssetFolder) = nothing
 
 subdir(asset::Union{BinaryAsset,Asset}) = string(mediatype(asset))
+
+desired_location(assetfolder, asset::Link) = link.target
+write_to_assetfolder(assetfolder, asset::Link) = link.target
 
 function desired_location(assetfolder, asset)
     folder = abspath(assetfolder.folder)
@@ -70,17 +74,16 @@ function desired_location(assetfolder, asset)
 end
 
 function desired_location(assetfolder, asset::BinaryAsset)
-    dir = assetfolder.folder isa Ref ? assetfolder.folder[] : assetfolder.folder
-    folder = abspath(dir)
+    dir = folder(assetfolder)
     file = unique_file_key(asset)
     sub = subdir(asset)
-    return normpath(joinpath(folder, "jsserve", sub, file))
+    return normpath(joinpath(dir, "jsserve", sub, file))
 end
 
 function write_to_assetfolder(assetfolder, asset)
-    folder = abspath(assetfolder.folder)
+    dir = folder(assetfolder)
     path = abspath(local_path(asset))
-    if occursin(folder, path)
+    if occursin(dir, path)
         return path
     else
         filepath = desired_location(assetfolder, asset)
@@ -90,12 +93,29 @@ function write_to_assetfolder(assetfolder, asset)
     end
 end
 
+current_dir(assetfolder::AssetFolder) = assetfolder.current_dir
+current_dir(assetfolder) = ""
+
+to_unix_path(path) = replace(path, "\\" => "/")
+
+function url(assetfolder::AbstractAssetFolder, asset::Link)
+    html_dir = to_unix_path(current_dir(assetfolder))
+    root_dir = to_unix_path(folder(assetfolder))
+    path_to_root = relpath(root_dir, html_dir)
+    return path_to_root * asset.target
+end
+
 function url(assetfolder::AbstractAssetFolder, asset::Asset)
     if !isempty(asset.online_path)
         return asset.online_path
     end
     path = write_to_assetfolder(assetfolder, asset)
-    return "./" * replace(normpath(relpath(path, folder(assetfolder))), "\\" => "/")
+    html_dir = to_unix_path(current_dir(assetfolder))
+    root_dir = to_unix_path(folder(assetfolder))
+    target_dir = to_unix_path(dirname(path))
+    relative = replace(target_dir, root_dir => "")
+    path_to_root = relpath(root_dir, html_dir)
+    return path_to_root * relative * "/" * basename(path)
 end
 
 folder(assetfolder::AssetFolder) = abspath(assetfolder.folder)

--- a/src/asset-serving/no-server.jl
+++ b/src/asset-serving/no-server.jl
@@ -99,6 +99,7 @@ current_dir(assetfolder) = ""
 to_unix_path(path) = replace(path, "\\" => "/")
 
 function url(assetfolder::AbstractAssetFolder, asset::Link)
+    is_online(asset.target) && return asset.target
     html_dir = to_unix_path(current_dir(assetfolder))
     root_dir = to_unix_path(folder(assetfolder))
     path_to_root = relpath(root_dir, html_dir)
@@ -118,6 +119,7 @@ function url(assetfolder::AbstractAssetFolder, asset::Asset)
     return path_to_root * relative * "/" * basename(path)
 end
 
+folder(folder) = folder.folder
 folder(assetfolder::AssetFolder) = abspath(assetfolder.folder)
 
 function url(assetfolder::AbstractAssetFolder, asset::BinaryAsset)

--- a/src/export.jl
+++ b/src/export.jl
@@ -189,14 +189,14 @@ function export_static(html_io::IO, app::App;
     return session
 end
 
-function export_static(folder::String, routes::Routes; connection=NoConnection(), asset_server=AssetFolder(folder))
+function export_static(folder::String, routes::Routes; connection=NoConnection(), asset_server= AssetFolder(folder, ""))
     isdir(folder) || mkpath(folder)
     for (route, app) in routes.routes
-        if route == "/"
-            route = "index"
-        end
-        html_file = normpath(joinpath(folder, route) * ".html")
+        startswith(route, "/") && (route = route[2:end])
+        dir = joinpath(folder, route)
+        html_file = normpath(joinpath(dir, "index.html"))
         isdir(dirname(html_file)) || mkpath(dirname(html_file))
+        asset_server.current_dir = dir
         export_static(html_file, app; session=Session(connection; asset_server=asset_server))
     end
 end

--- a/src/export.jl
+++ b/src/export.jl
@@ -53,9 +53,6 @@ function (ignore::IgnoreObsUpdates2)(msg)
         # because otherwise, that will trigger itself recursively, once those messages are applied
         # via `$(wid).on(x=> ....)`
         msg[:id] in ignore.widget_ids && return true
-        if msg[:payload] isa Vector
-            @show length(msg[:payload])
-        end
     end
     return false
 end
@@ -72,7 +69,7 @@ function record_values(f, session, widget_ids)
         do_session(session) do s
             append!(messages, s.message_queue)
         end
-        return unique(messages)
+        return messages
     catch e
         Base.showerror(stderr, e)
     finally

--- a/src/export.jl
+++ b/src/export.jl
@@ -53,6 +53,9 @@ function (ignore::IgnoreObsUpdates2)(msg)
         # because otherwise, that will trigger itself recursively, once those messages are applied
         # via `$(wid).on(x=> ....)`
         msg[:id] in ignore.widget_ids && return true
+        if msg[:payload] isa Vector
+            @show length(msg[:payload])
+        end
     end
     return false
 end
@@ -69,7 +72,7 @@ function record_values(f, session, widget_ids)
         do_session(session) do s
             append!(messages, s.message_queue)
         end
-        return messages
+        return unique(messages)
     catch e
         Base.showerror(stderr, e)
     finally
@@ -132,7 +135,6 @@ function record_states(session::Session, dom::Hyperscript.Node)
             console.log(states)
             // messages to send for this state of that observable
             const messages = statemap[states]
-            console.log(messages)
             // not all states trigger events
             // so some states won't have any messages recorded
             if (messages){
@@ -187,7 +189,7 @@ function export_static(html_io::IO, app::App;
     return session
 end
 
-function export_static(folder::String, routes::Routes; connection=NoConnection(), asset_server=NoServer())
+function export_static(folder::String, routes::Routes; connection=NoConnection(), asset_server=AssetFolder(folder))
     isdir(folder) || mkpath(folder)
     for (route, app) in routes.routes
         if route == "/"
@@ -197,4 +199,13 @@ function export_static(folder::String, routes::Routes; connection=NoConnection()
         isdir(dirname(html_file)) || mkpath(dirname(html_file))
         export_static(html_file, app; session=Session(connection; asset_server=asset_server))
     end
+end
+
+
+
+function export_static(routes)
+    dir = joinpath(@__DIR__, "docs")
+    # rm(dir; recursive=true, force=true); mkdir(dir)
+    folder = AssetFolder(dir)
+    JSServe.export_static(dir, routes; asset_server=folder)
 end

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -1,0 +1,43 @@
+function update_route!(server, (route, app))
+    old = route!(server, route => app)
+    if old isa App && !isnothing(old.session[]) && isready(old.session[])
+        try
+            JSServe.evaljs(old.session[], js"window.location.reload()")
+        catch e
+            @warn "Failed to reload route $(route)" exception = e
+        end
+    end
+end
+
+function interactive_server(f, paths, modules=[]; url="127.0.0.1", port=8081, track_main_includes=true, all=false)
+    server = Server(url, port)
+    if isdefined(Main, :Revise)
+        R = Main.Revise
+        R.tracking_Main_includes[] = track_main_includes
+        routes_channel = Channel{Routes}(1)
+        task = @async R.entr(paths, modules; all=all) do
+            routes = f()
+            for (route, app) in routes.routes
+                update_route!(server, (route, app))
+            end
+            put!(routes_channel, routes)
+        end
+        Base.timedwait(10) do
+            istaskfailed(task) || isready(routes_channel)
+        end
+        if istaskfailed(task)
+            fetch(task)
+        end
+        errormonitor(task)
+        routes = take!(routes_channel)
+        server_routes = Set(first.(server.routes.table))
+        if !Base.all(r-> r in server_routes, keys(routes.routes))
+            @warn "not all routes in server. Required routes: $(first(routes.routes)). Routes in server: $(server_routes)"
+        end
+        page = haskey(routes.routes, "/") ? "/" : first(routes.routes)[1]
+        HTTPServer.openurl(online_url(server, page))
+        return routes, task, server
+    else
+        error("Please load Revise into Main scope")
+    end
+end

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -9,7 +9,6 @@ function update_route!(server, (route, app))
     end
 end
 
-
 const REVISE_LOOP = Base.RefValue(Base.RefValue(true))
 const REVISE_SERVER = Base.RefValue{Union{Nothing, Server}}(nothing)
 

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -15,7 +15,7 @@ function interactive_server(f, paths, modules=[]; url="127.0.0.1", port=8081, tr
         R = Main.Revise
         R.tracking_Main_includes[] = track_main_includes
         routes_channel = Channel{Routes}(1)
-        task = @async R.entr(paths, modules; all=all) do
+        R.entr(paths, modules; all=all) do
             routes = f()
             for (route, app) in routes.routes
                 update_route!(server, (route, app))

--- a/src/rendering/hyperscript_integration.jl
+++ b/src/rendering/hyperscript_integration.jl
@@ -110,7 +110,7 @@ function attribute_render(session::Session, parent, attribute::String, jss::JSCo
     return ""
 end
 
-function attribute_render(session::Session, parent, attribute::String, asset::Asset)
+function attribute_render(session::Session, parent, attribute::String, asset::Union{Link, Asset})
     if parent isa Hyperscript.Node{Hyperscript.CSS}
         # css seems to require an url object
         return "url($(url(session, asset)))"

--- a/src/rendering/jsrender.jl
+++ b/src/rendering/jsrender.jl
@@ -7,7 +7,7 @@ To enable putting YourType into a dom element/div.
 You can also overload it to take a session as first argument, to register
 messages with the current web session (e.g. via onjs).
 """
-jsrender(::Session, value::Union{String,Symbol}) = string(value)
+jsrender(::Session, value::Union{String,Symbol,Number}) = string(value)
 jsrender(::Nothing) = DOM.span()
 jsrender(@nospecialize(x)) = x
 

--- a/src/rendering/markdown_integration.jl
+++ b/src/rendering/markdown_integration.jl
@@ -9,7 +9,9 @@ function md_html(session::Session, content::Vector)
 end
 
 function md_html(session::Session, header::Markdown.Header{l}) where l
-    return [DOM.m("h$l", htmlinline(session, header.text)...)]
+    title = header.text
+    id = length(title) == 1 && title[1] isa String ? title[1] : ""
+    return [DOM.m("h$l", htmlinline(session, header.text)...; id=id)]
 end
 
 function md_html(session::Session, code::Markdown.Code)
@@ -43,7 +45,7 @@ function md_html(session::Session, md::Markdown.List)
         map(md.items) do item
             DOM.m("li", md_html(session, item)...)
         end...
-    )]
+        ; style="list-style-type: disc; list-style: inside;")]
 end
 
 function md_html(session::Session, md::Markdown.HorizontalRule)
@@ -63,7 +65,7 @@ function md_html(session::Session, md::Markdown.Table)
 end
 
 function htmlinline(session::Session, content::Vector)
-    return htmlinline.((session,), content)
+    return [htmlinline.((session,), content)...]
 end
 
 function htmlinline(session::Session, code::Markdown.Code)

--- a/src/tailwind-dashboard.jl
+++ b/src/tailwind-dashboard.jl
@@ -11,7 +11,7 @@ function FlexRow(args...; class="", attributes...)
         TailwindMini,
         args...;
         attributes...,
-        class="m-2 flex flex-row $class",
+        class="mx-2 flex flex-row $class",
     )
 end
 
@@ -20,7 +20,7 @@ function FlexCol(args...; class="", attributes...)
         TailwindMini,
         args...;
         attributes...,
-        class="m-2 flex flex-col $class",
+        class="my-2 flex flex-col $class",
     )
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -281,5 +281,5 @@ struct Routes
 end
 
 Routes() = Routes(Dict{String, App}())
-
+Routes(pairs::Pair{String, App}...) = Routes(Dict{String, App}(pairs))
 Base.setindex!(routes::Routes, app::App, key::String) = (routes.routes[key] = app)

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,6 +39,10 @@ struct Asset
     bundle_dir::Union{String, Path}
 end
 
+struct Link
+    target::String
+end
+
 struct JSException <: Exception
     exception::String
     message::String


### PR DESCRIPTION
Enables workflow like this:
```julia
using Revise, JSServe, Markdown
import JSServe.TailwindDashboard as D

includet("src/html-classes.jl")
includet("src/index.jl")
includet("src/github.jl")
includet("src/support.jl")
includet("src/team.jl")
includet("src/contact.jl")

routes, task, server = interactive_server([asset_path(), joinpath(@__DIR__, "src")]) do
    return Routes(
        "/" => index,
        "/team" => team,
        "/contact" => contact,
        "/support" => support
    )
end

```

See: https://github.com/MakieOrg/Website/blob/sd/jsserve/make.jl#L1-L21