### PR TITLE
Option to disable the devtools panel when creating Electron windows

### DIFF
--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -169,11 +169,11 @@ display(example_app)
 ![](electron.png)
 
 !!! note
-    By default, `JSServe` will create the Electron window with an open Developer
-    Tools panel in order to help debugging. You can control this behavior at
+    By default, `JSServe` will create the Electron window without showing the Developer
+    Tools panel. You can control this behavior at
     window creation using the `devtools` keyword arg:
     ```
-    display = JSServe.use_electron_display(devtools = false)
+    display = JSServe.use_electron_display(devtools = true)
     ```
     Alternatively, you can toggle the Developer Tools at any later time using:
     ```

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -168,6 +168,18 @@ display(example_app)
 ```
 ![](electron.png)
 
+!!! note
+    By default, `JSServe` will create the Electron window with an open Developer
+    Tools panel in order to help debugging. You can control this behavior at
+    window creation using the `devtools` keyword arg:
+    ```
+    display = JSServe.use_electron_display(devtools = false)
+    ```
+    Alternatively, you can toggle the Developer Tools at any later time using:
+    ```
+    Electron.toggle_devtools(display.window)
+    ```
+
 ## Documenter
 
 JSServe works in Documenter without additional setup.

--- a/src/HTTPServer/browser-display.jl
+++ b/src/HTTPServer/browser-display.jl
@@ -113,9 +113,9 @@ struct ElectronDisplay{EWindow} <: Base.Multimedia.AbstractDisplay
     browserdisplay::BrowserDisplay
 end
 
-function ElectronDisplay()
+function ElectronDisplay(; devtools = true)
     w = Electron().Window()
-    Electron().toggle_devtools(w)
+    devtools && Electron().toggle_devtools(w)
     return ElectronDisplay(w, BrowserDisplay(; open_browser=false))
 end
 
@@ -131,8 +131,8 @@ function Base.display(display::ElectronDisplay, app::App)
     return display
 end
 
-function use_electron_display()
-    disp = ElectronDisplay()
+function use_electron_display(; devtools = true)
+    disp = ElectronDisplay(; devtools = devtools)
     Base.Multimedia.pushdisplay(disp)
     return disp
 end

--- a/src/HTTPServer/browser-display.jl
+++ b/src/HTTPServer/browser-display.jl
@@ -113,7 +113,7 @@ struct ElectronDisplay{EWindow} <: Base.Multimedia.AbstractDisplay
     browserdisplay::BrowserDisplay
 end
 
-function ElectronDisplay(; devtools = true)
+function ElectronDisplay(; devtools = false)
     w = Electron().Window()
     devtools && Electron().toggle_devtools(w)
     return ElectronDisplay(w, BrowserDisplay(; open_browser=false))
@@ -131,7 +131,7 @@ function Base.display(display::ElectronDisplay, app::App)
     return display
 end
 
-function use_electron_display(; devtools = true)
+function use_electron_display(; devtools = false)
     disp = ElectronDisplay(; devtools = devtools)
     Base.Multimedia.pushdisplay(disp)
     return disp


### PR DESCRIPTION
This PR introduces a new keyword argument for `JSServe.use_electron_display`: calling
```
use_electron_display(devtools = false)
```
avoids opening the Developer Tools panel in the newly created Electon window. The default behavior (when no argument is specified) is unchanged.

The PR also documents how to toggle the devtools panel for an already created Electron Display.

Does this need explicit testing in your opinion? I'm not sure exactly how to test that an Electron window has its devtools panel open or not...

Fixes: #184 