### PR TITLE
Fix memory leak with DisplayHandler

### DIFF
--- a/src/HTTPServer/helper.jl
+++ b/src/HTTPServer/helper.jl
@@ -23,5 +23,6 @@ function response_500(exception)
     ], body=body)
 end
 
-# TODO, can we n
-# Base.convert(::Type{HTTP.Response}, s::Exception) = response_500(s)
+# TODO, how to do this without pircay? THis happens inside HTTP, so we can't just use try & catch in our own code
+# WIthout this overload, we'll get a `cant convert Exception to HTTP.Response` error, without seeing the error.
+Base.convert(::Type{HTTP.Response}, s::Exception) = response_500(s)

--- a/src/serialization/caching.jl
+++ b/src/serialization/caching.jl
@@ -26,7 +26,8 @@ function register_observable!(session::Session, obs::Observable)
     # Only register one time
     if !haskey(root.session_objects, obs.id)
         updater = JSUpdateObservable(root, obs.id)
-        on(updater, root, obs)
+        deregister = on(updater, obs)
+        push!(session.deregister_callbacks, deregister)
     end
     return
 end


### PR DESCRIPTION
For long standing sessions as is the case with `BrowserDisplay` or in notebooks/vscode, deregister callbacks would accumulate unbounded, since they would be added to the root session, which will never be freed.

This little change adds them to the correct child session, so they get freed properly.
This shouldn't concern the server use case, as a new root session is created for every request.

Also adds an error conversion, that I forgot to push, which improves error display in certain edge cases.